### PR TITLE
Pc/pytorch requeriments

### DIFF
--- a/integrations-and-supported-tools/pytorch/notebooks/Neptune_PyTorch_Support.ipynb
+++ b/integrations-and-supported-tools/pytorch/notebooks/Neptune_PyTorch_Support.ipynb
@@ -22,7 +22,7 @@
    },
    "outputs": [],
    "source": [
-    "! pip install neptune-client numpy==1.19.5 torch==1.8.1 torchvision==0.10.0"
+    "! pip install neptune-client numpy==1.19.5 torch==1.9.0 torchvision==0.10.0"
    ]
   },
   {

--- a/integrations-and-supported-tools/pytorch/scripts/requirements.txt
+++ b/integrations-and-supported-tools/pytorch/scripts/requirements.txt
@@ -1,5 +1,5 @@
 neptune-client
 numpy==1.19.5
-torch==1.8.1
+torch==1.9.0
 torchvision==0.10.0
 


### PR DESCRIPTION
PyTorch v1.8.1 throws an error when installed alongside torchvision v0.10.0. 

This PR is the fix! 