### PR TITLE
Bump fastai version to most recent

### DIFF
--- a/integrations-and-supported-tools/fastai/notebooks/Neptune_fastai.ipynb
+++ b/integrations-and-supported-tools/fastai/notebooks/Neptune_fastai.ipynb
@@ -19,7 +19,7 @@
    },
    "outputs": [],
    "source": [
-    "! pip install fastai==2.3.1 neptune-client[fastai]"
+    "! pip install fastai==2.7.2 neptune-client[fastai]"
    ]
   },
   {

--- a/integrations-and-supported-tools/fastai/scripts/requirements.txt
+++ b/integrations-and-supported-tools/fastai/scripts/requirements.txt
@@ -1,3 +1,3 @@
-fastai==2.3.1
+fastai==2.7.2
 neptune-client
 neptune-fastai


### PR DESCRIPTION
Our tutorial example for fastai was failing with the error `RuntimeError: Could not infer dtype of PILImage`. It seems like it's a [bug in fastai](https://forums.fast.ai/t/runtimeerror-could-not-infer-dtype-of-pilimage/89697/5). I bumped the version to the most recent and it works again.