### PR TITLE
Removed deprecated `set-output` in scheduled tests

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -49,15 +49,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Get pip cache dir
         id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
       - name: pip cache
         uses: actions/cache@v3.0.11
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ inputs.os }}-${{ matrix.python-version }}-pip
-          restore-keys: |
-            ${{ inputs.os }}-${{ matrix.python-version }}-pip
+          restore-keys: ${{ inputs.os }}-${{ matrix.python-version }}-pip
       - name: Install OpenMP on MacOS for XGBoost integration
         if: runner.os == 'macOS'
         run: brew install libomp

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -44,15 +44,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Get pip cache dir
         id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
       - name: pip cache
         uses: actions/cache@v3.0.11
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ inputs.os }}-${{ matrix.python-version }}-pip
-          restore-keys: |
-            ${{ inputs.os }}-${{ matrix.python-version }}-pip
+          restore-keys: ${{ inputs.os }}-${{ matrix.python-version }}-pip
       - name: Install OpenMP on MacOS for XGBoost integration
         if: runner.os == 'macOS'
         run: brew install libomp


### PR DESCRIPTION
# Description

Replaced deprecated `set-output` command with github env variables. https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

__Related to:__ `(ClickUp/JIRA task name)`

---

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

Mark which items have been completed:

- [ ] Refactored code ([sourcery](https://sourcery.ai/))
- [ ] Tested code locally
- [X] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)

### 🪝 Run the following to both [pre-commit](https://pre-commit.com/) hooks and JupyterLab (turn on `format on save`)

- [ ] Stripped outputs from notebooks - ([nbstripout](https://pypi.org/project/nbstripout/))
- [ ] Sorted imports - ([isort](https://pycqa.github.io/isort/))
- [ ] Formatted code - ([back](https://github.com/psf/black))

### 📄 Update documentation

Coordinate with @normandy7

- [ ] Updated content in the [docs](https://docs.neptune.ai)
- [ ] Added to all relevant docs index pages (e.g., [Examples](https://docs.neptune.ai/getting-started/examples), [Integrations intro](https://docs.neptune.ai/integrations-and-supported-tools/intro), [Model training index](https://docs.neptune.ai/integrations-and-supported-tools/model-training))
- [ ] Added to examples [README](../README.md)

---

## 🧪 Test Configuration

- OS:
- Python version:
- Neptune version:
- Affected libraries with version:

---

## ✔️ Post-merge checklist

These tasks should be done after the code is merged to main. Create a subtask under the main ClickUp task to have these on your radar and share the subtask here.

__Post-merge subtask:__ `(ClickUp/JIRA task name)`

- [ ] Update relevant blogs with impacted code/functionality (Contact @Patrycja-J for the list of blogs)
- [ ] Add functionality under the Neptune column of the `competitor comparison sheet` (Coordinate with @SiddhantSadangi)
- [ ] Update integration README (Contact @Patrycja-J)
