### PR TITLE
Adjust docs items in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,9 +33,8 @@ Mark which items have been completed:
 
 Coordinate with @normandy7
 
-- [ ] Updated content in the [docs](https://docs.neptune.ai)
-- [ ] Added to all relevant docs index pages (e.g., [Examples](https://docs.neptune.ai/getting-started/examples), [Integrations intro](https://docs.neptune.ai/integrations-and-supported-tools/intro), [Model training index](https://docs.neptune.ai/integrations-and-supported-tools/model-training))
-- [ ] Added to examples [README](../README.md)
+- [ ] Update content in the [docs](https://docs.neptune.ai)
+- [ ] (For new content) Add links to examples [README](../README.md)
 
 ---
 


### PR DESCRIPTION
I think we can make do with one "update docs" item which can be checked as soon as the changes are understood and taken into account. That is, for new content, the new docs page does not need to be published before a PR can be merged.

If the docs content is added later (which I think will more often be the case now that we have a separate docs team), I'll take over the responsibility to add links and update the examples README once the content is published.

What do you think?

Signed-off-by: Sabine <sabine.nyholm@neptune.ai>