### PR TITLE
Adding instructions for colab users

### DIFF
--- a/integrations-and-supported-tools/pytorch-lightning/notebooks/Neptune_PyTorch_Lightning.ipynb
+++ b/integrations-and-supported-tools/pytorch-lightning/notebooks/Neptune_PyTorch_Lightning.ipynb
@@ -59,6 +59,16 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: If running on Google Colab, please restart the kernel and continue execution from the next cell to avoid a `ContextualVersionConflict` error.\n",
+    "\n",
+    "This error is caused due to colab coming with `future==0.16.0` preinstalled, while `torchvision` updates this to a newer version."
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "tags": [

--- a/integrations-and-supported-tools/pytorch-lightning/notebooks/Neptune_PyTorch_Lightning.ipynb
+++ b/integrations-and-supported-tools/pytorch-lightning/notebooks/Neptune_PyTorch_Lightning.ipynb
@@ -63,9 +63,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note**: If running on Google Colab, please restart the kernel and continue execution from the next cell to avoid a `ContextualVersionConflict` error.\n",
+    "**Note**: If running on Google Colab, restart the kernel and continue execution from the next cell to avoid a `ContextualVersionConflict` error.\n",
     "\n",
-    "This error is caused due to colab coming with `future==0.16.0` preinstalled, while `torchvision` updates this to a newer version."
+    "This error is caused by Colab coming with `future==0.16.0` preinstalled, while `torchvision` updates this to a newer version."
    ]
   },
   {


### PR DESCRIPTION
# Description

Added instructions for colab users to avoid `ContextualVersionConflict` error.

__Related to:__ `(ClickUp/JIRA task name)`

__Any expected test failures?__
Tests might fail on python 3.11

---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [ ] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: 
- Python version:
- Neptune version:
- Affected libraries with version:
