### PR TITLE
Fix for Compare_model_training_runs_on_dataset_versions

### DIFF
--- a/how-to-guides/data-versioning/notebooks/Compare_model_training_runs_on_dataset_versions.ipynb
+++ b/how-to-guides/data-versioning/notebooks/Compare_model_training_runs_on_dataset_versions.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "id": "QDR4PVLPwrx6",
     "tags": [
      "header"
     ]
@@ -14,6 +15,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "id": "V-3yhAGowrx8",
     "tags": [
      "header"
     ]
@@ -38,6 +40,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "id": "-7YjuyJ4wrx9",
     "tags": [
      "header",
      "installation"
@@ -56,7 +59,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "n79e8ys-wrx_"
+   },
    "source": [
     "## Install Neptune and dependencies"
    ]
@@ -65,6 +70,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 1000
+    },
+    "id": "gMhEDs4uwrx_",
+    "outputId": "be29d192-7b2e-43f9-cc9b-b661e772b579",
     "tags": [
      "installation"
     ]
@@ -75,8 +86,34 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "DbRjEopuzLrZ",
+    "outputId": "cb6bf505-f63a-4f4e-99a0-1a1acc99216c"
+   },
+   "outputs": [],
+   "source": [
+    "! curl https://raw.githubusercontent.com/neptune-ai/examples/main/how-to-guides/data-versioning/datasets/tables/train.csv --create-dirs -o ../datasets/tables/train.csv\n",
+    "! curl https://raw.githubusercontent.com/neptune-ai/examples/main/how-to-guides/data-versioning/datasets/tables/test.csv --create-dirs -o ../datasets/tables/test.csv\n",
+    "! curl https://raw.githubusercontent.com/neptune-ai/examples/main/how-to-guides/data-versioning/datasets/tables/train_v2.csv --create-dirs -o ../datasets/tables/train_v2.csv"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
+    "id": "VDruBecswryA",
     "tags": [
      "header"
     ]
@@ -88,6 +125,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "id": "LX3rTEUEwryB",
     "tags": [
      "comment"
     ]
@@ -100,6 +138,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "id": "EjgIGTaewryB",
     "tags": [
      "code"
     ]
@@ -137,7 +176,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
+    "id": "mTvZuwZVwryC",
     "tags": [
      "header"
     ]
@@ -149,6 +188,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "id": "4mu1_YCawryC",
     "tags": [
      "comment"
     ]
@@ -161,7 +201,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab_type": "code",
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Ar6jlEGQwryD",
+    "outputId": "a954d427-ee6f-4e0b-a5ba-35f42c0c8f9b",
     "tags": [
      "code"
     ]
@@ -176,6 +220,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "id": "p_WumFTOwryD",
     "tags": [
      "comment"
     ]
@@ -187,9 +232,9 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
+    "id": "mvm2WHk6wryE",
     "tags": [
      "comment"
     ]
@@ -229,6 +274,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "id": "33YNYeBdwryF",
     "tags": [
      "header"
     ]
@@ -240,6 +286,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "id": "bSaZjsPRwryF",
     "tags": [
      "comment"
     ]
@@ -252,6 +299,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "id": "08M0RznfwryF",
     "tags": [
      "code"
     ]
@@ -264,7 +312,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "Qcfyt15xwryG"
+   },
    "source": [
     "**Note:**\n",
     "\n",
@@ -281,14 +331,18 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "CU6q73dvwryG"
+   },
    "source": [
     "## Run model training and log parameters and metrics to Neptune"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "kdbc45d4wryH"
+   },
    "source": [
     "Now train a model and log the test score to Neptune"
    ]
@@ -296,7 +350,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "ZF79ppatwryH",
+    "outputId": "70b37f0e-82b0-442a-bb24-98f62008c546"
+   },
    "outputs": [],
    "source": [
     "run[\"parameters\"] = params\n",
@@ -308,7 +368,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "3w1_A-uTwryH"
+   },
    "source": [
     "## Stop logging to the current run \n",
     "<font color=red>**Warning:**</font><br>\n",
@@ -319,7 +381,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Z-nclmkGwryI",
+    "outputId": "4428a0bf-fd3b-4a1d-f527-7ba426c18f0a"
+   },
    "outputs": [],
    "source": [
     "run.stop()"
@@ -327,7 +395,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "-SLOx1I2wryI"
+   },
    "source": [
     "## Change training dataset\n",
     "\n",
@@ -337,7 +407,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "ElQ_4DKSwryI"
+   },
    "outputs": [],
    "source": [
     "TRAIN_DATASET_PATH = \"../datasets/tables/train_v2.csv\""
@@ -345,7 +417,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "K8nEx-m6wryI"
+   },
    "source": [
     "## Run model training on a new training dataset\n",
     "\n",
@@ -356,7 +430,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "uNrehlgXwryI",
+    "outputId": "642c3f36-c237-40a4-82ad-de2e759e96b1"
+   },
    "outputs": [],
    "source": [
     "new_run = neptune.init_run(project=\"common/data-versioning\", api_token=neptune.ANONYMOUS_API_TOKEN)"
@@ -364,7 +444,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "LFwQNkwGwryI"
+   },
    "source": [
     "* Log dataset versions"
    ]
@@ -372,7 +454,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "avfma1a4wryJ"
+   },
    "outputs": [],
    "source": [
     "new_run[\"datasets/train\"].track_files(TRAIN_DATASET_PATH)\n",
@@ -381,7 +465,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "IFvRXkKowryJ"
+   },
    "source": [
     "* Execute model training"
    ]
@@ -389,7 +475,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Xe_g4W7iwryJ",
+    "outputId": "01178f8c-efc4-4753-83c8-0ac64fa5a40b"
+   },
    "outputs": [],
    "source": [
     "new_run[\"parameters\"] = params\n",
@@ -401,7 +493,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "X1MKpdlwwryJ"
+   },
    "source": [
     "Stop logging to currently active Neptune run"
    ]
@@ -409,7 +503,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "hW1N6kuHwryK",
+    "outputId": "bf619f50-6395-4703-8dec-5ebfd3c43a9b"
+   },
    "outputs": [],
    "source": [
     "new_run.stop()"
@@ -418,6 +518,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "id": "N8y1TKowwryK",
     "tags": [
      "comment"
     ]
@@ -437,6 +538,15 @@
   }
  ],
  "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "gpuClass": "standard",
+  "kernelspec": {
+   "display_name": "py38",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -447,14 +557,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.8.15"
   },
   "vscode": {
    "interpreter": {
-    "hash": "ec001e92a202bf5caf822e845ea5ad1be0f2e89477ccf084fef05c1d70e5b02a"
+    "hash": "a9715cf0b0024f6e1c62cb31a4f1f43970eb41991212681878768b4bfe53050a"
    }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }

--- a/how-to-guides/data-versioning/notebooks/Organize_and_share_dataset_versions.ipynb
+++ b/how-to-guides/data-versioning/notebooks/Organize_and_share_dataset_versions.ipynb
@@ -56,6 +56,31 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "DbRjEopuzLrZ",
+    "outputId": "cb6bf505-f63a-4f4e-99a0-1a1acc99216c"
+   },
+   "outputs": [],
+   "source": [
+    "! curl https://raw.githubusercontent.com/neptune-ai/examples/main/how-to-guides/data-versioning/datasets/tables/train.csv --create-dirs -o ../datasets/tables/train.csv\n",
+    "! curl https://raw.githubusercontent.com/neptune-ai/examples/main/how-to-guides/data-versioning/datasets/tables/test.csv --create-dirs -o ../datasets/tables/test.csv\n",
+    "! curl https://raw.githubusercontent.com/neptune-ai/examples/main/how-to-guides/data-versioning/datasets/tables/train_v2.csv --create-dirs -o ../datasets/tables/train_v2.csv"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/how-to-guides/data-versioning/notebooks/Version_datasets_in_model_training_runs.ipynb
+++ b/how-to-guides/data-versioning/notebooks/Version_datasets_in_model_training_runs.ipynb
@@ -56,6 +56,31 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "DbRjEopuzLrZ",
+    "outputId": "cb6bf505-f63a-4f4e-99a0-1a1acc99216c"
+   },
+   "outputs": [],
+   "source": [
+    "! curl https://raw.githubusercontent.com/neptune-ai/examples/main/how-to-guides/data-versioning/datasets/tables/train.csv --create-dirs -o ../datasets/tables/train.csv\n",
+    "! curl https://raw.githubusercontent.com/neptune-ai/examples/main/how-to-guides/data-versioning/datasets/tables/test.csv --create-dirs -o ../datasets/tables/test.csv\n",
+    "! curl https://raw.githubusercontent.com/neptune-ai/examples/main/how-to-guides/data-versioning/datasets/tables/train_v2.csv --create-dirs -o ../datasets/tables/train_v2.csv"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/how-to-guides/data-versioning/scripts/Compare_model_training_runs_on_dataset_versions.py
+++ b/how-to-guides/data-versioning/scripts/Compare_model_training_runs_on_dataset_versions.py
@@ -5,9 +5,9 @@ import pandas as pd
 import requests
 from sklearn.ensemble import RandomForestClassifier
 
-dataset_path = Path.relative_to(
-    Path.absolute(Path(__file__)).parent.parent.joinpath("datasets/tables"), Path.cwd()
-)
+# Download dataset
+
+dataset_path = Path.relative_to(Path.absolute(Path(__file__)).parent, Path.cwd())
 
 for file in ["train.csv", "test.csv", "train_v2.csv"]:
     r = requests.get(

--- a/how-to-guides/data-versioning/scripts/Compare_model_training_runs_on_dataset_versions.py
+++ b/how-to-guides/data-versioning/scripts/Compare_model_training_runs_on_dataset_versions.py
@@ -1,9 +1,26 @@
+from pathlib import Path
+
 import neptune.new as neptune
 import pandas as pd
+import requests
 from sklearn.ensemble import RandomForestClassifier
 
-TRAIN_DATASET_PATH = "../datasets/tables/train.csv"
-TEST_DATASET_PATH = "../datasets/tables/test.csv"
+dataset_path = Path.relative_to(
+    Path.absolute(Path(__file__)).parent.parent.joinpath("datasets/tables"), Path.cwd()
+)
+
+for file in ["train.csv", "test.csv", "train_v2.csv"]:
+    r = requests.get(
+        f"https://raw.githubusercontent.com/neptune-ai/examples/main/how-to-guides/data-versioning/datasets/tables/{file}",
+        allow_redirects=True,
+    )
+
+    open(dataset_path.joinpath(file), "wb").write(r.content)
+
+
+TRAIN_DATASET_PATH = str(dataset_path.joinpath("train.csv"))
+TEST_DATASET_PATH = str(dataset_path.joinpath("test.csv"))
+
 
 params = {
     "n_estimators": 7,
@@ -53,7 +70,7 @@ run.stop()
 # Run model training log dataset version, parameter and test score to Neptune
 #
 
-TRAIN_DATASET_PATH = "../datasets/tables/train_v2.csv"
+TRAIN_DATASET_PATH = str(dataset_path.joinpath("train_v2.csv"))
 
 # Create a new Neptune run and start logging
 new_run = neptune.init_run(project="common/data-versioning", api_token=neptune.ANONYMOUS_API_TOKEN)

--- a/how-to-guides/data-versioning/scripts/Organize_and_share_dataset_versions.py
+++ b/how-to-guides/data-versioning/scripts/Organize_and_share_dataset_versions.py
@@ -22,7 +22,7 @@ project = neptune.init_project(
 )
 
 # Create a few versions of a dataset and save them to Neptune
-train = pd.read_csv("../datasets/train.csv")
+train = pd.read_csv(str(dataset_path.joinpath("train.csv")))
 
 for i in range(5):
     train_sample = train.sample(frac=0.5 + 0.1 * i)

--- a/how-to-guides/data-versioning/scripts/Organize_and_share_dataset_versions.py
+++ b/how-to-guides/data-versioning/scripts/Organize_and_share_dataset_versions.py
@@ -8,7 +8,7 @@ from sklearn.ensemble import RandomForestClassifier
 # Download dataset
 dataset_path = Path.relative_to(Path.absolute(Path(__file__)).parent, Path.cwd())
 
-for file in ["train.csv", "test.csv", "train_v2.csv"]:
+for file in ["train_sampled.csv", "test.csv"]:
     r = requests.get(
         f"https://raw.githubusercontent.com/neptune-ai/examples/main/how-to-guides/data-versioning/datasets/tables/{file}",
         allow_redirects=True,
@@ -26,8 +26,10 @@ train = pd.read_csv("../datasets/train.csv")
 
 for i in range(5):
     train_sample = train.sample(frac=0.5 + 0.1 * i)
-    train_sample.to_csv("../datasets/train_sampled.csv", index=None)
-    project[f"datasets/train_sampled/v{i}"].track_files("../datasets/train_sampled.csv", wait=True)
+    train_sample.to_csv(str(dataset_path.joinpath("train_sampled.csv")), index=None)
+    project[f"datasets/train_sampled/v{i}"].track_files(
+        str(dataset_path.joinpath("train_sampled.csv")), wait=True
+    )
 
 print(project.get_structure())
 
@@ -54,12 +56,12 @@ print(project.get_structure()["datasets"])
 run = neptune.init_run(project="common/data-versioning", api_token=neptune.ANONYMOUS_API_TOKEN)
 
 # Assert that you are training on the latest dataset
-TRAIN_DATASET_PATH = "../datasets/train_sampled.csv"
+TRAIN_DATASET_PATH = str(dataset_path.joinpath("train_sampled.csv"))
 run["datasets/train"].track_files(TRAIN_DATASET_PATH, wait=True)
 
 assert run["datasets/train"].fetch_hash() == project["datasets/train_sampled/latest"].fetch_hash()
 
-TEST_DATASET_PATH = "../datasets/test.csv"
+TEST_DATASET_PATH = str(dataset_path.joinpath("test.csv"))
 
 # Log parameters
 params = {

--- a/how-to-guides/data-versioning/scripts/Version_datasets_in_model_training_runs.py
+++ b/how-to-guides/data-versioning/scripts/Version_datasets_in_model_training_runs.py
@@ -1,9 +1,23 @@
+from pathlib import Path
+
 import neptune.new as neptune
 import pandas as pd
+import requests
 from sklearn.ensemble import RandomForestClassifier
 
-TRAIN_DATASET_PATH = "../datasets/tables/train.csv"
-TEST_DATASET_PATH = "../datasets/tables/test.csv"
+# Download dataset
+dataset_path = Path.relative_to(Path.absolute(Path(__file__)).parent, Path.cwd())
+
+for file in ["train.csv", "test.csv"]:
+    r = requests.get(
+        f"https://raw.githubusercontent.com/neptune-ai/examples/main/how-to-guides/data-versioning/datasets/tables/{file}",
+        allow_redirects=True,
+    )
+
+    open(dataset_path.joinpath(file), "wb").write(r.content)
+
+TRAIN_DATASET_PATH = str(dataset_path.joinpath("train.csv"))
+TEST_DATASET_PATH = str(dataset_path.joinpath("test.csv"))
 
 
 def train_model(params, train_path, test_path):

--- a/how-to-guides/data-versioning/scripts/requirements.txt
+++ b/how-to-guides/data-versioning/scripts/requirements.txt
@@ -1,2 +1,3 @@
 neptune-client
+requests
 scikit-learn


### PR DESCRIPTION
# Description

* Downloading data during runtime
* Handling path resolution for all execution modes (and taking into account [neptune issue with tracking windows absolute paths](https://docs.neptune.ai/logging/artifacts/#passing-an-absolute-windows-file-path))

__Related to:__ `fix test errors`

__Any expected test failures?__
All failures are intentional `AssertionError`s

---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [X] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: Windows11
- Python version: 3.8.15
- Neptune version:
- Affected libraries with version:
