### PR TITLE
Fixing sacred notebook test error

### DIFF
--- a/integrations-and-supported-tools/sacred/notebooks/Neptune_Sacred.ipynb
+++ b/integrations-and-supported-tools/sacred/notebooks/Neptune_Sacred.ipynb
@@ -236,7 +236,7 @@
     "@ex.main\n",
     "def run(data_dir, data_tfms, lr, bs, device, _run):\n",
     "    trainset = datasets.CIFAR10(data_dir, transform=data_tfms[\"train\"], download=True)\n",
-    "    trainloader = torch.utils.data.DataLoader(trainset, batch_size=bs, shuffle=True, num_workers=2)\n",
+    "    trainloader = torch.utils.data.DataLoader(trainset, batch_size=bs, shuffle=True, num_workers=0)\n",
     "    model.to(device)\n",
     "    criterion = nn.CrossEntropyLoss()\n",
     "    optimizer = optim.SGD(model.parameters(), lr=lr)\n",
@@ -374,7 +374,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15 | packaged by conda-forge | (default, Nov 22 2022, 08:42:03) [MSC v.1929 64 bit (AMD64)]"
+   "version": "3.8.15"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
# Description

Setting `num_workers=0`

__Related to:__ `fix test errors`

__Any expected test failures?__
Tests will fail on python 3.11

---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [ ] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: Windows 11
- Python version: 3.8.15
- Neptune version: 0.16.17
- Affected libraries with version:
