### PR TITLE
Updated kedro example for v1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ You can run every example with zero setup as an "ANONYMOUS" Neptune user (no reg
 
 | | Docs | Neptune | GitHub | Colab
 | ----------- | :---: | :---: | :------: | :---:
-| Kedro | [![docs]](https://docs.neptune.ai/integrations/kedro) | [![neptune]](https://app.neptune.ai/o/common/org/kedro-integration/e/KED-1285/dashboard/Basic-pipeline-metadata-42874940-da74-4cdc-94a4-315a7cdfbfa8) | [![github]](integrations-and-supported-tools/kedro/scripts) | |
+| Kedro | [![docs]](https://docs.neptune.ai/integrations/kedro) | [![neptune]](https://app.neptune.ai/o/common/org/kedro-integration/e/KED-1563/dashboard/Basic-pipeline-metadata-42874940-da74-4cdc-94a4-315a7cdfbfa8) | [![github]](integrations-and-supported-tools/kedro/scripts) | |
 
 ### Experiment Tracking
 

--- a/integrations-and-supported-tools/kedro/scripts/kedro-neptune-advanced/src/kedro_neptune_advanced/nodes.py
+++ b/integrations-and-supported-tools/kedro/scripts/kedro-neptune-advanced/src/kedro_neptune_advanced/nodes.py
@@ -6,7 +6,7 @@ generated using Kedro 0.18.4
 from typing import Any, Dict, Tuple
 
 import matplotlib.pyplot as plt
-import neptune.new as neptune
+import neptune
 import numpy as np
 import pandas as pd
 from scikitplot.metrics import plot_precision_recall, plot_roc

--- a/integrations-and-supported-tools/kedro/scripts/kedro-neptune-quickstart/src/kedro_neptune_quickstart/nodes.py
+++ b/integrations-and-supported-tools/kedro/scripts/kedro-neptune-quickstart/src/kedro_neptune_quickstart/nodes.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any, Dict, Tuple
 
 import matplotlib.pyplot as plt
-import neptune.new as neptune
+import neptune
 import numpy as np
 import pandas as pd
 from scikitplot.metrics import plot_confusion_matrix

--- a/integrations-and-supported-tools/kedro/scripts/requirements.txt
+++ b/integrations-and-supported-tools/kedro/scripts/requirements.txt
@@ -1,7 +1,7 @@
 kedro
 kedro-neptune
 matplotlib
-neptune-client<1.0.0
+neptune
 numpy
 pandas
 scikit-learn


### PR DESCRIPTION
# Description

Updated kedro example for neptune>=1.0.0

__Related to:__ `update examples`

__Any expected test failures?__
Tests will fail on python 3.11

---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [ ] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: Windows11
- Python version: 3.8.15
- Neptune version: 1.0.2
- Affected libraries with version: kedro-neptune==0.1.5
