### PR TITLE
matplotlib prophet workaround

### DIFF
--- a/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
+++ b/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
@@ -60,7 +60,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -U neptune[prophet] prophet"
+    "! pip install -U neptune[prophet] prophet\n",
+    "! pip install -U matplotlib"
    ]
   },
   {

--- a/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
+++ b/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -U \"neptune[prophet]\" prophet \"pandas<2.0\" \"matplotlib<3.5\""
+    "! pip install -U \"matplotlib<3.5\" \"neptune[prophet]\" \"pandas<2.0\" prophet plotly"
    ]
   },
   {

--- a/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
+++ b/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
@@ -95,7 +95,7 @@
     "run = neptune.init_run(\n",
     "    project=\"workspace-name/project-name\",  # replace with your own (see instructions below)\n",
     "    api_token=getpass(\"Enter your Neptune API token: \"),\n",
-    "    tags=[\"prophet\", \"artifacts\", \"notebook\"],  # optional\n",
+    "    tags=[\"prophet\", \"notebook\"],  # optional\n",
     ")\n",
     "```\n",
     "\n",
@@ -118,7 +118,7 @@
     "run = neptune.init_run(\n",
     "    project=\"common/fbprophet-integration\",\n",
     "    api_token=neptune.ANONYMOUS_API_TOKEN,\n",
-    "    tags=[\"prophet\", \"artifacts\", \"notebook\"],  # optional\n",
+    "    tags=[\"prophet\", \"notebook\"],  # optional\n",
     ")"
    ]
   },
@@ -209,7 +209,9 @@
    "source": [
     "import neptune.integrations.prophet as npt_utils\n",
     "\n",
-    "run[\"prophet_summary\"] = npt_utils.create_summary(model=model, df=df, fcst=forecast)"
+    "run[\"prophet_summary\"] = npt_utils.create_summary(\n",
+    "    model=model, df=df, fcst=forecast, log_interactive=True\n",
+    ")"
    ]
   },
   {
@@ -314,7 +316,7 @@
     "run = neptune.init_run(\n",
     "    project=\"common/fbprophet-integration\",\n",
     "    api_token=neptune.ANONYMOUS_API_TOKEN,\n",
-    "    tags=[\"prophet\", \"artifacts\", \"notebook\"],  # optional\n",
+    "    tags=[\"prophet\", \"notebook\"],  # optional\n",
     ")"
    ]
   },

--- a/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
+++ b/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -U \"matplotlib<3.5\" \"neptune[prophet]\" \"pandas<2.0\" prophet plotly"
+    "! pip install -U \"matplotlib<3.5\" \"neptune[prophet]\" \"pandas<2.0\" prophet"
    ]
   },
   {
@@ -210,7 +210,9 @@
     "import neptune.integrations.prophet as npt_utils\n",
     "\n",
     "run[\"prophet_summary\"] = npt_utils.create_summary(\n",
-    "    model=model, df=df, fcst=forecast, log_interactive=True\n",
+    "    model=model,\n",
+    "    df=df,\n",
+    "    fcst=forecast,\n",
     ")"
    ]
   },

--- a/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
+++ b/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
@@ -60,8 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -U neptune[prophet] prophet\n",
-    "! pip install -U matplotlib"
+    "! pip install -U \"neptune[prophet]\" prophet \"pandas<2.0\" \"matplotlib<3.5\""
    ]
   },
   {

--- a/integrations-and-supported-tools/prophet/scripts/Neptune_prophet.py
+++ b/integrations-and-supported-tools/prophet/scripts/Neptune_prophet.py
@@ -31,5 +31,7 @@ model.fit(df)
 forecast = model.predict(df)
 
 run["prophet_summary"] = npt_utils.create_summary(
-    model=model, df=df, fcst=forecast, log_interactive=True
+    model=model,
+    df=df,
+    fcst=forecast,
 )

--- a/integrations-and-supported-tools/prophet/scripts/Neptune_prophet.py
+++ b/integrations-and-supported-tools/prophet/scripts/Neptune_prophet.py
@@ -30,4 +30,6 @@ model.fit(df)
 
 forecast = model.predict(df)
 
-run["prophet_summary"] = npt_utils.create_summary(model=model, df=df, fcst=forecast)
+run["prophet_summary"] = npt_utils.create_summary(
+    model=model, df=df, fcst=forecast, log_interactive=True
+)

--- a/integrations-and-supported-tools/prophet/scripts/requirements.txt
+++ b/integrations-and-supported-tools/prophet/scripts/requirements.txt
@@ -1,5 +1,4 @@
 matplotlib<3.5
 neptune[prophet]
 pandas<2.0
-plotly
 prophet

--- a/integrations-and-supported-tools/prophet/scripts/requirements.txt
+++ b/integrations-and-supported-tools/prophet/scripts/requirements.txt
@@ -1,4 +1,5 @@
 matplotlib<3.5
 neptune[prophet]
 pandas<2.0
+plotly
 prophet

--- a/integrations-and-supported-tools/prophet/scripts/requirements.txt
+++ b/integrations-and-supported-tools/prophet/scripts/requirements.txt
@@ -1,2 +1,4 @@
+matplotlib<3.5
 neptune[prophet]
+pandas<2.0
 prophet

--- a/integrations-and-supported-tools/prophet/scripts/run_examples.sh
+++ b/integrations-and-supported-tools/prophet/scripts/run_examples.sh
@@ -2,9 +2,10 @@ set -e
 
 echo "Installing requirements..."
 pip install -U -r requirements.txt
+pip install -U matplotlib
 
-echo "Running Neptune_prophet.pys..."
+echo "Running Neptune_prophet.py..."
 python Neptune_prophet.py
 
-echo "Running Neptune_prophet_more_options.pys..."
+echo "Running Neptune_prophet_more_options.py..."
 python Neptune_prophet_more_options.py

--- a/integrations-and-supported-tools/prophet/scripts/run_examples.sh
+++ b/integrations-and-supported-tools/prophet/scripts/run_examples.sh
@@ -6,5 +6,5 @@ pip install -U -r requirements.txt
 echo "Running Neptune_prophet.py..."
 python Neptune_prophet.py
 
-# echo "Running Neptune_prophet_more_options.py..."
-# python Neptune_prophet_more_options.py
+echo "Running Neptune_prophet_more_options.py..."
+python Neptune_prophet_more_options.py

--- a/integrations-and-supported-tools/prophet/scripts/run_examples.sh
+++ b/integrations-and-supported-tools/prophet/scripts/run_examples.sh
@@ -6,5 +6,5 @@ pip install -U -r requirements.txt
 echo "Running Neptune_prophet.py..."
 python Neptune_prophet.py
 
-echo "Running Neptune_prophet_more_options.py..."
-python Neptune_prophet_more_options.py
+# echo "Running Neptune_prophet_more_options.py..."
+# python Neptune_prophet_more_options.py

--- a/integrations-and-supported-tools/prophet/scripts/run_examples.sh
+++ b/integrations-and-supported-tools/prophet/scripts/run_examples.sh
@@ -2,7 +2,6 @@ set -e
 
 echo "Installing requirements..."
 pip install -U -r requirements.txt
-pip install -U matplotlib
 
 echo "Running Neptune_prophet.py..."
 python Neptune_prophet.py


### PR DESCRIPTION
# Description

Added constraints to matplotlib and pandas versions

__Related to:__ fix test errors

__Any expected test failures?__
On Windows, tests will fail on python 3.10+ due to matplotlib<3.5 installation 

---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [ ] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: Windows11
- Python version: 3.8.15
- Neptune version: 1.3.0
- Affected libraries with version: matplotlib<3.5, prophet==1.1.4, neptune-prophet==1.0.0, pandas<2.0
