### PR TITLE
Setting `as_frame=True`

### DIFF
--- a/integrations-and-supported-tools/evidently/notebooks/Neptune_Evidently.ipynb
+++ b/integrations-and-supported-tools/evidently/notebooks/Neptune_Evidently.ipynb
@@ -131,8 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iris_data = datasets.load_iris(as_frame=\"auto\")\n",
-    "iris_frame = iris_data.frame"
+    "iris_frame = datasets.load_iris(as_frame=True).frame"
    ]
   },
   {
@@ -552,7 +551,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.10.11"
   },
   "vscode": {
    "interpreter": {

--- a/integrations-and-supported-tools/evidently/scripts/Neptune_Evidently_reports.py
+++ b/integrations-and-supported-tools/evidently/scripts/Neptune_Evidently_reports.py
@@ -7,8 +7,7 @@ from neptune.utils import stringify_unsupported
 from sklearn import datasets
 
 # Load sample data
-iris_data = datasets.load_iris(as_frame="auto")
-iris_frame = iris_data.frame
+iris_frame = datasets.load_iris(as_frame=True).frame
 
 # Run Evidently test suites and reports
 data_stability = TestSuite(
@@ -35,8 +34,8 @@ data_drift_report.run(
 
 # (Neptune) Start a run
 run = neptune.init_run(
-    api_token=neptune.ANONYMOUS_API_TOKEN,
-    project="common/evidently-support",
+    api_token=neptune.ANONYMOUS_API_TOKEN,  # replace with your own
+    project="common/evidently-support",  # replace with your own
     tags=["reports"],  # (optional) replace with your own
 )
 


### PR DESCRIPTION
# Description

scikit-learn>=1.3.0 expects `as_frame` to be boolean and "auto" is not longer accepted

__Related to:__ Fix test errors

__Any expected test failures?__


---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [x] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: Widows11
- Python version: 3.10.11
- Neptune version: 1.5.0
- Affected libraries with version: scikit-learn==1.3.0
