### PR TITLE
fix: link to open notebook in colab

### DIFF
--- a/integrations-and-supported-tools/colab/Neptune_Colab.ipynb
+++ b/integrations-and-supported-tools/colab/Neptune_Colab.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "# Neptune + Google Colab\n",
     "\n",
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/neptune-ai/examples/blob/main/integrations-and-supported-tools/colab/notebooks/Neptune_Colab.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/neptune-ai/examples/blob/main/integrations-and-supported-tools/colab/Neptune_Colab.ipynb\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open in Colab\"/>\n",
     "</a>\n",
     "\n",


### PR DESCRIPTION
# Description

The "open in colab" link, which was also used in a blog post, is wrong and leads to a 404.

__Related to:__ https://app.clickup.com/t/8692nv0z9

__Any expected test failures?__


---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [ ] Refactored code ([sourcery](https://sourcery.ai/))
- [ ] Tested code locally
- [ ] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS:
- Python version:
- Neptune version:
- Affected libraries with version:
