### PR TITLE
Unpinning matplotlib and pandas

### DIFF
--- a/integrations-and-supported-tools/matplotlib/notebooks/Neptune_Matplotlib_Support.ipynb
+++ b/integrations-and-supported-tools/matplotlib/notebooks/Neptune_Matplotlib_Support.ipynb
@@ -76,8 +76,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -U -q neptune plotly\n",
-    "! pip install -U -q matplotlib --user"
+    "%pip install -U -q neptune plotly\n",
+    "%pip install -U -q matplotlib --user"
    ]
   },
   {

--- a/integrations-and-supported-tools/matplotlib/notebooks/Neptune_Matplotlib_Support.ipynb
+++ b/integrations-and-supported-tools/matplotlib/notebooks/Neptune_Matplotlib_Support.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -U \"matplotlib<3.5\" neptune plotly"
+    "%pip install -U -q matplotlib neptune plotly"
    ]
   },
   {
@@ -308,7 +308,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.11"
   },
   "toc-autonumbering": false,
   "toc-showcode": false,

--- a/integrations-and-supported-tools/matplotlib/notebooks/Neptune_Matplotlib_Support.ipynb
+++ b/integrations-and-supported-tools/matplotlib/notebooks/Neptune_Matplotlib_Support.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -U -q matplotlib neptune plotly"
+    "! pip install -U -q matplotlib neptune plotly"
    ]
   },
   {

--- a/integrations-and-supported-tools/matplotlib/notebooks/Neptune_Matplotlib_Support.ipynb
+++ b/integrations-and-supported-tools/matplotlib/notebooks/Neptune_Matplotlib_Support.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -U -q neptune plotly\n",
+    "%pip install -U -q neptune plotly matplotlib\n",
     "%pip install -U -q matplotlib --user"
    ]
   },

--- a/integrations-and-supported-tools/matplotlib/notebooks/Neptune_Matplotlib_Support.ipynb
+++ b/integrations-and-supported-tools/matplotlib/notebooks/Neptune_Matplotlib_Support.ipynb
@@ -76,8 +76,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -U -q neptune plotly\n",
-    "%pip install -U -q matplotlib --user"
+    "! pip install -U -q neptune plotly\n",
+    "! pip install -U -q matplotlib --user"
    ]
   },
   {

--- a/integrations-and-supported-tools/matplotlib/notebooks/Neptune_Matplotlib_Support.ipynb
+++ b/integrations-and-supported-tools/matplotlib/notebooks/Neptune_Matplotlib_Support.ipynb
@@ -76,7 +76,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -U -q matplotlib neptune plotly"
+    "%pip install -U -q neptune plotly\n",
+    "%pip install -U -q matplotlib --user"
    ]
   },
   {

--- a/integrations-and-supported-tools/matplotlib/scripts/requirements.txt
+++ b/integrations-and-supported-tools/matplotlib/scripts/requirements.txt
@@ -1,3 +1,3 @@
-matplotlib<3.5 # Constraint required only if matplotlib figure has to be converted to plotly figure
+matplotlib
 neptune
 plotly

--- a/integrations-and-supported-tools/matplotlib/scripts/run_examples.sh
+++ b/integrations-and-supported-tools/matplotlib/scripts/run_examples.sh
@@ -1,7 +1,7 @@
 set -e
 
 echo "Installing requirements..."
-pip install -U -r requirements.txt
+pip install -U -r requirements.txt --user
 
 echo "Running Neptune_Matplotlib_Support.py..."
 python Neptune_Matplotlib_Support.py

--- a/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
+++ b/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
@@ -70,7 +70,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -U -q matplotlib \"neptune[prophet]\" pandas prophet"
+    "%pip install -U -q neptune[prophet] pandas prophet\n",
+    "%pip install -U -q matplotlib --user"
    ]
   },
   {
@@ -339,6 +340,19 @@
    "metadata": {},
    "source": [
     "Open the link above to see the metadata logging results, as we add them below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03a30332",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run this if you get a `RuntimeError: main thread is not in main loop` error\n",
+    "import matplotlib\n",
+    "\n",
+    "matplotlib.use(\"Agg\")"
    ]
   },
   {

--- a/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
+++ b/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -U -q \"neptune[prophet]\" \"pandas<2.0\" prophet\n",
+    "%pip install -U -q \"neptune[prophet]\" \"pandas<2.0\" prophet matplotlib\n",
     "%pip install -U -q matplotlib --user"
    ]
   },

--- a/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
+++ b/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
@@ -70,8 +70,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -U -q neptune[prophet] pandas prophet\n",
-    "%pip install -U -q matplotlib --user"
+    "! pip install -U -q neptune[prophet] pandas prophet\n",
+    "! pip install -U -q matplotlib --user"
    ]
   },
   {

--- a/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
+++ b/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
@@ -70,8 +70,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -U -q neptune[prophet] pandas prophet\n",
-    "! pip install -U -q matplotlib --user"
+    "%pip install -U -q \"neptune[prophet]\" \"pandas<2.0\" prophet\n",
+    "%pip install -U -q matplotlib --user"
    ]
   },
   {

--- a/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
+++ b/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -U -q matplotlib \"neptune[prophet]\" pandas prophet"
+    "! pip install -U -q matplotlib \"neptune[prophet]\" pandas prophet"
    ]
   },
   {

--- a/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
+++ b/integrations-and-supported-tools/prophet/notebooks/Neptune_prophet.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -U \"matplotlib<3.5\" \"neptune[prophet]\" \"pandas<2.0\" prophet"
+    "%pip install -U -q matplotlib \"neptune[prophet]\" pandas prophet"
    ]
   },
   {

--- a/integrations-and-supported-tools/prophet/scripts/requirements.txt
+++ b/integrations-and-supported-tools/prophet/scripts/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib<3.5
+matplotlib
 neptune[prophet]
-pandas<2.0
+pandas
 prophet

--- a/integrations-and-supported-tools/prophet/scripts/requirements.txt
+++ b/integrations-and-supported-tools/prophet/scripts/requirements.txt
@@ -1,4 +1,4 @@
 matplotlib
 neptune[prophet]
-pandas
+pandas<2.0
 prophet

--- a/integrations-and-supported-tools/prophet/scripts/run_examples.sh
+++ b/integrations-and-supported-tools/prophet/scripts/run_examples.sh
@@ -1,7 +1,7 @@
 set -e
 
 echo "Installing requirements..."
-pip install -U -r requirements.txt
+pip install -U -r requirements.txt --user
 
 echo "Running Neptune_prophet.py..."
 python Neptune_prophet.py

--- a/use-cases/time-series-forecasting/walmart-sales/requirements.txt
+++ b/use-cases/time-series-forecasting/walmart-sales/requirements.txt
@@ -1,7 +1,7 @@
 lightning
 neptune[prophet,xgboost]
 numpy
-pandas
+pandas<2.0
 plotly
 prophet
 scikit-learn

--- a/use-cases/time-series-forecasting/walmart-sales/requirements.txt
+++ b/use-cases/time-series-forecasting/walmart-sales/requirements.txt
@@ -1,7 +1,7 @@
 lightning
 neptune[prophet,xgboost]
 numpy
-pandas<2.0
+pandas
 plotly
 prophet
 scikit-learn

--- a/use-cases/time-series-forecasting/walmart-sales/scripts/run_examples.sh
+++ b/use-cases/time-series-forecasting/walmart-sales/scripts/run_examples.sh
@@ -3,7 +3,7 @@ set -e
 export NEPTUNE_PROJECT="common/project-time-series-forecasting"
 
 echo "Installing requirements..."
-pip install -U -r ../requirements.txt
+pip install -U -r ../requirements.txt --user
 
 echo "Running run_ml_baseline.py..."
 python run_ml_baseline.py


### PR DESCRIPTION
# Description

Unpinning matplotlib and pandas after plotly bugfix [#4372](https://github.com/plotly/plotly.py/pull/4372)

__Related to:__ fix test errors

__Any expected test failures?__


---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [X] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: Windows11
- Python version: 3.10.11
- Neptune version: 1.8.2
- Affected libraries with version: matplotlib==3.8.0, pandas==1.5.3, plotly==5.18.0 
