### PR TITLE
Pinned scipy to <1.12

### DIFF
--- a/integrations-and-supported-tools/lightgbm/notebooks/Neptune_LightGBM.ipynb
+++ b/integrations-and-supported-tools/lightgbm/notebooks/Neptune_LightGBM.ipynb
@@ -79,7 +79,7 @@
    },
    "outputs": [],
    "source": [
-    "! pip install -U graphviz lightgbm \"neptune[lightgbm]\" scipy<1.12"
+    "%pip install -U graphviz lightgbm \"neptune[lightgbm]\" \"scipy<1.12\""
    ]
   },
   {

--- a/integrations-and-supported-tools/lightgbm/notebooks/Neptune_LightGBM.ipynb
+++ b/integrations-and-supported-tools/lightgbm/notebooks/Neptune_LightGBM.ipynb
@@ -79,7 +79,7 @@
    },
    "outputs": [],
    "source": [
-    "! pip install -U graphviz lightgbm \"neptune[lightgbm]\""
+    "! pip install -U graphviz lightgbm \"neptune[lightgbm]\" scipy<1.12"
    ]
   },
   {

--- a/integrations-and-supported-tools/lightgbm/scripts/requirements.txt
+++ b/integrations-and-supported-tools/lightgbm/scripts/requirements.txt
@@ -1,3 +1,4 @@
 graphviz
 lightgbm
 neptune[lightgbm]
+scipy<1.12


### PR DESCRIPTION
# Description

Pinned scipy to <1.12 to prevent `ImportError`

__Related to:__ Fix test errors

__Any expected test failures?__


---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [X] Refactored code ([sourcery](https://sourcery.ai/))
- [ ] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS:
- Python version:
- Neptune version:
- Affected libraries with version: scipy>=1.12
