### PR TITLE
Pinned scipy to <1.12

### DIFF
--- a/integrations-and-supported-tools/pytorch-lightning/notebooks/Neptune_PyTorch_Lightning.ipynb
+++ b/integrations-and-supported-tools/pytorch-lightning/notebooks/Neptune_PyTorch_Lightning.ipynb
@@ -74,7 +74,7 @@
    "outputs": [],
    "source": [
     "%pip install -U neptune lightning scikit-plot torchvision \"scipy<1.12\"\n",
-    "%pip install -U --user pydantic \"scipy<1.12\""
+    "%pip install -U --user pydantic"
    ]
   },
   {

--- a/integrations-and-supported-tools/pytorch-lightning/notebooks/Neptune_PyTorch_Lightning.ipynb
+++ b/integrations-and-supported-tools/pytorch-lightning/notebooks/Neptune_PyTorch_Lightning.ipynb
@@ -73,7 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -U neptune lightning scikit-plot torchvision\n",
+    "%pip install -U neptune lightning scikit-plot torchvision \"scipy<1.12\"\n",
     "%pip install -U --user pydantic"
    ]
   },

--- a/integrations-and-supported-tools/pytorch-lightning/notebooks/Neptune_PyTorch_Lightning.ipynb
+++ b/integrations-and-supported-tools/pytorch-lightning/notebooks/Neptune_PyTorch_Lightning.ipynb
@@ -74,7 +74,7 @@
    "outputs": [],
    "source": [
     "%pip install -U neptune lightning scikit-plot torchvision \"scipy<1.12\"\n",
-    "%pip install -U --user pydantic"
+    "%pip install -U --user pydantic \"scipy<1.12\""
    ]
   },
   {

--- a/integrations-and-supported-tools/pytorch-lightning/scripts/requirements.txt
+++ b/integrations-and-supported-tools/pytorch-lightning/scripts/requirements.txt
@@ -2,5 +2,6 @@ lightning
 neptune
 pydantic
 scikit-plot
+scipy<1.12
 torch
 torchvision


### PR DESCRIPTION
# Description

Pinned scipy to <1.12 to prevent `ImportError: cannot import name 'interp' from 'scipy'`

__Related to:__ Fix test errors

__Any expected test failures?__


---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [ ] Refactored code ([sourcery](https://sourcery.ai/))
- [ ] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS:
- Python version:
- Neptune version:
- Affected libraries with version: scipy 1.12
