### PR TITLE
Hopefully fixing detectron2 installation issue on macos for python>=3.11

### DIFF
--- a/integrations-and-supported-tools/detectron2/scripts/run_examples.sh
+++ b/integrations-and-supported-tools/detectron2/scripts/run_examples.sh
@@ -4,8 +4,12 @@ echo "Installing requirements..."
 pip install -U -r requirements.txt
 
 echo "Installing detectron2..."
+python -m pip install ninja
 if [[ "$OSTYPE" == "darwin"* ]]; then
-CC=clang CXX=clang++ ARCHFLAGS="-arch x86_64" python -m pip install -U 'git+https://github.com/facebookresearch/detectron2.git' --no-build-isolation
+export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1
+pip install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+CC=clang CXX=clang++ ARCHFLAGS="-arch x86_64" python -m pip install -U 'git+https://github.com/facebookresearch/detectron2.git'
 else
 pip install -U 'git+https://github.com/facebookresearch/detectron2.git' --no-build-isolation
 fi


### PR DESCRIPTION
# Description

Added additional installation prerequisites

__Related to:__ Fix test errors

__Any expected test failures?__


---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [ ] Refactored code ([sourcery](https://sourcery.ai/))
- [ ] Tested code locally
- [ ] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS:
- Python version:
- Neptune version:
- Affected libraries with version:
