### PR TITLE
Removed manual image scaling

### DIFF
--- a/how-to-guides/hello-neptune/notebooks/hello_neptune.ipynb
+++ b/how-to-guides/hello-neptune/notebooks/hello_neptune.ipynb
@@ -281,7 +281,7 @@
     "for i in range(10):\n",
     "    run[\"image_series\"].append(\n",
     "        File.as_image(\n",
-    "            train_images[i] / 255\n",
+    "            train_images[i]\n",
     "        ),  # You can upload arrays as images using Neptune's File.as_image() method\n",
     "        name=f\"{train_labels[i]}\",\n",
     "    )"

--- a/how-to-guides/hello-neptune/scripts/hello_neptune.py
+++ b/how-to-guides/hello-neptune/scripts/hello_neptune.py
@@ -39,7 +39,7 @@ from neptune.types import File
 for i in range(10):
     run["image_series"].append(
         File.as_image(
-            train_images[i] / 255
+            train_images[i]
         ),  # You can upload arrays as images using Neptune's File.as_image() method
         name=f"{train_labels[i]}",
     )

--- a/how-to-guides/monitor-ml-runs/notebooks/Monitor_ML_runs_live.ipynb
+++ b/how-to-guides/monitor-ml-runs/notebooks/Monitor_ML_runs_live.ipynb
@@ -121,7 +121,6 @@
     "\n",
     "mnist = keras.datasets.mnist\n",
     "(x_train, y_train), (x_test, y_test) = mnist.load_data()\n",
-    "x_train, x_test = x_train / 255.0, x_test / 255.0\n",
     "\n",
     "model = keras.models.Sequential(\n",
     "    [\n",

--- a/how-to-guides/monitor-ml-runs/scripts/Monitor_ML_runs_live.py
+++ b/how-to-guides/monitor-ml-runs/scripts/Monitor_ML_runs_live.py
@@ -15,7 +15,6 @@ params = {
 
 mnist = keras.datasets.mnist
 (x_train, y_train), (x_test, y_test) = mnist.load_data()
-x_train, x_test = x_train / 255.0, x_test / 255.0
 
 model = keras.models.Sequential(
     [

--- a/integrations-and-supported-tools/airflow/scripts/Neptune_Airflow.py
+++ b/integrations-and-supported-tools/airflow/scripts/Neptune_Airflow.py
@@ -11,7 +11,6 @@ from neptune_airflow import NeptuneLogger
 
 def data_details(logger: NeptuneLogger, **context):
     (x_train, y_train), (x_test, y_test) = tf.keras.datasets.mnist.load_data()
-    x_train = x_train / 255.0
 
     # (Neptune) This will be logged relative to `task_name/{namespace}` (including the context)
     with logger.get_task_handler_from_context(context=context, log_context=True) as handler:
@@ -26,7 +25,6 @@ def data_details(logger: NeptuneLogger, **context):
 def train_model(logger: NeptuneLogger, **context):
     with logger.get_task_handler_from_context(context=context) as handler:
         (x_train, y_train), _ = tf.keras.datasets.mnist.load_data()
-        x_train = x_train / 255.0
 
         model = tf.keras.models.Sequential(
             [
@@ -68,7 +66,6 @@ def evaluate_model(logger: NeptuneLogger, **context):
         # run["model_checkpoint"].download()
         model = tf.keras.models.load_model("model_checkpoint.keras")
         _, (x_test, y_test) = tf.keras.datasets.mnist.load_data()
-        x_test = x_test / 255.0
 
         for image, label in zip(x_test[:10], y_test[:10]):
             prediction = model.predict(image[None], verbose=0)

--- a/integrations-and-supported-tools/detectron2/notebooks/Neptune_detectron2.ipynb
+++ b/integrations-and-supported-tools/detectron2/notebooks/Neptune_detectron2.ipynb
@@ -436,7 +436,7 @@
     "    out = v.draw_instance_predictions(outputs[\"instances\"].to(\"cpu\"))\n",
     "    image = out.get_image()[:, :, ::-1]\n",
     "    img_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)\n",
-    "    run[f\"training/prediction_visualization/{idx}\"].upload(File.as_image(img_rgb / 255.0))"
+    "    run[f\"training/prediction_visualization/{idx}\"].upload(File.as_image(img_rgb))"
    ]
   },
   {

--- a/integrations-and-supported-tools/detectron2/scripts/Neptune_detectron2.py
+++ b/integrations-and-supported-tools/detectron2/scripts/Neptune_detectron2.py
@@ -138,7 +138,7 @@ for idx, d in enumerate(random.sample(dataset_dicts, 3)):
     out = v.draw_instance_predictions(outputs["instances"].to("cpu"))
     image = out.get_image()[:, :, ::-1]
     img_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-    run[f"training/prediction_visualization/{idx}"].upload(File.as_image(img_rgb / 255.0))
+    run[f"training/prediction_visualization/{idx}"].upload(File.as_image(img_rgb))
 
 # (Neptune) Once you are done logging, stop tracking the run.
 run.stop()

--- a/integrations-and-supported-tools/fastai/notebooks/Neptune_fastai.ipynb
+++ b/integrations-and-supported-tools/fastai/notebooks/Neptune_fastai.ipynb
@@ -392,7 +392,7 @@
     "    # fastai uses their own tensor type name TensorImage\n",
     "    # so you have to convert it back to torch.Tensor\n",
     "    run[\"images/one_batch\"].append(\n",
-    "        File.as_image(x.as_subclass(torch.Tensor).permute(2, 1, 0) / 255.0),\n",
+    "        File.as_image(x.as_subclass(torch.Tensor).permute(2, 1, 0)),\n",
     "        name=f\"{i}\",\n",
     "        description=f\"Label: {y}\",\n",
     "    )"

--- a/integrations-and-supported-tools/fastai/scripts/Neptune_fastai_more_options.py
+++ b/integrations-and-supported-tools/fastai/scripts/Neptune_fastai_more_options.py
@@ -92,7 +92,7 @@ for i, (x, y) in enumerate(dls.decode_batch(batch)):
     # fastai uses their own tensor type name TensorImage
     # so you have to convert it back to torch.Tensor
     run["images/one_batch"].append(
-        File.as_image(x.as_subclass(torch.Tensor).permute(2, 1, 0) / 255.0),
+        File.as_image(x.as_subclass(torch.Tensor).permute(2, 1, 0)),
         name=f"{i}",
         description=f"Label: {y}",
     )

--- a/integrations-and-supported-tools/keras/notebooks/Neptune_Keras.ipynb
+++ b/integrations-and-supported-tools/keras/notebooks/Neptune_Keras.ipynb
@@ -125,7 +125,6 @@
    "source": [
     "mnist = tf.keras.datasets.mnist\n",
     "(x_train, y_train), (x_test, y_test) = mnist.load_data()\n",
-    "x_train, x_test = x_train / 255.0, x_test / 255.0\n",
     "\n",
     "model = tf.keras.models.Sequential(\n",
     "    [\n",

--- a/integrations-and-supported-tools/keras/scripts/Neptune_Keras.py
+++ b/integrations-and-supported-tools/keras/scripts/Neptune_Keras.py
@@ -10,7 +10,6 @@ run = neptune.init_run(
 
 mnist = tf.keras.datasets.mnist
 (x_train, y_train), (x_test, y_test) = mnist.load_data()
-x_train, x_test = x_train / 255.0, x_test / 255.0
 
 model = tf.keras.models.Sequential(
     [

--- a/integrations-and-supported-tools/keras/scripts/Neptune_Keras_more_options.py
+++ b/integrations-and-supported-tools/keras/scripts/Neptune_Keras_more_options.py
@@ -8,7 +8,6 @@ from tensorflow.keras.callbacks import ModelCheckpoint
 # Prepare dataset
 mnist = tf.keras.datasets.mnist
 (x_train, y_train), (x_test, y_test) = mnist.load_data()
-x_train, x_test = x_train / 255.0, x_test / 255.0
 
 # Build and compile model
 params = {"lr": 0.005, "momentum": 0.7, "epochs": 15, "batch_size": 256}

--- a/integrations-and-supported-tools/mosaicml-composer/notebooks/Neptune_MosaicML_Composer.ipynb
+++ b/integrations-and-supported-tools/mosaicml-composer/notebooks/Neptune_MosaicML_Composer.ipynb
@@ -331,7 +331,7 @@
    "source": [
     "from neptune.types import File\n",
     "\n",
-    "neptune_logger.base_handler[\"sample_image\"].upload(File.as_image(train_dataset.data[0] / 255))"
+    "neptune_logger.base_handler[\"sample_image\"].upload(File.as_image(train_dataset.data[0]))"
    ]
   },
   {
@@ -354,7 +354,7 @@
    },
    "outputs": [],
    "source": [
-    "neptune_logger.neptune_run[\"eval/sample_image\"].upload(File.as_image(test_dataset.data[0] / 255))"
+    "neptune_logger.neptune_run[\"eval/sample_image\"].upload(File.as_image(test_dataset.data[0]))"
    ]
   },
   {

--- a/integrations-and-supported-tools/mosaicml-composer/scripts/Neptune_MosaicML_Composer.py
+++ b/integrations-and-supported-tools/mosaicml-composer/scripts/Neptune_MosaicML_Composer.py
@@ -98,10 +98,10 @@ trainer.fit()
 
 ## (Neptune) Log additional metadata
 
-neptune_logger.base_handler["sample_image"].upload(File.as_image(train_dataset.data[0] / 255))
+neptune_logger.base_handler["sample_image"].upload(File.as_image(train_dataset.data[0]))
 
 ## Log metadata to your custom namespace
-neptune_logger.neptune_run["eval/sample_image"].upload(File.as_image(test_dataset.data[0] / 255))
+neptune_logger.neptune_run["eval/sample_image"].upload(File.as_image(test_dataset.data[0]))
 
 ## Stop logging
 trainer.close()

--- a/integrations-and-supported-tools/skorch/notebooks/Neptune_Skorch.ipynb
+++ b/integrations-and-supported-tools/skorch/notebooks/Neptune_Skorch.ipynb
@@ -130,32 +130,6 @@
    ]
   },
   {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To avoid big weights that deal with the pixel values in the range [0, 255], we scale `X` down. A commonly used range is [0, 1]."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X /= 255.0"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X.min(), X.max()"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/integrations-and-supported-tools/skorch/scripts/Neptune_Skorch.py
+++ b/integrations-and-supported-tools/skorch/scripts/Neptune_Skorch.py
@@ -21,7 +21,6 @@ mnist = fetch_openml("mnist_784", as_frame=False, cache=False)
 # Preprocess data
 X = mnist.data.astype("float32")
 y = mnist.target.astype("int64")
-X /= 255.0
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25, random_state=42)
 
 # Build a neural network with PyTorch

--- a/integrations-and-supported-tools/skorch/scripts/Neptune_Skorch_more_options.py
+++ b/integrations-and-supported-tools/skorch/scripts/Neptune_Skorch_more_options.py
@@ -23,7 +23,7 @@ mnist = fetch_openml("mnist_784", as_frame=False, cache=False)
 # Preprocess data
 X = mnist.data.astype("float32")
 y = mnist.target.astype("int64")
-X /= 255.0
+
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25, random_state=42)
 
 # Build a neural network with PyTorch

--- a/integrations-and-supported-tools/tensorboard/notebooks/Neptune_Tensorflow_Tensorboard.ipynb
+++ b/integrations-and-supported-tools/tensorboard/notebooks/Neptune_Tensorflow_Tensorboard.ipynb
@@ -276,7 +276,7 @@
     "# Normalize data for training\n",
     "def normalize_img(image):\n",
     "    \"\"\"Normalizes images: `uint8` -> `float32`.\"\"\"\n",
-    "    return tf.cast(image, tf.float32) / 255.0\n",
+    "    return tf.cast(image, tf.float32)\n",
     "\n",
     "\n",
     "train_examples = normalize_img(train_examples)\n",

--- a/integrations-and-supported-tools/tensorboard/scripts/Neptune_Tensorflow_Tensorboard.py
+++ b/integrations-and-supported-tools/tensorboard/scripts/Neptune_Tensorflow_Tensorboard.py
@@ -50,7 +50,7 @@ for name, value in params.items():
 # Normalize data for training
 def normalize_img(image):
     """Normalizes images: `uint8` -> `float32`."""
-    return tf.cast(image, tf.float32) / 255.0
+    return tf.cast(image, tf.float32)
 
 
 train_examples = normalize_img(train_examples)

--- a/integrations-and-supported-tools/tensorflow/notebooks/Neptune_Tensorflow.ipynb
+++ b/integrations-and-supported-tools/tensorflow/notebooks/Neptune_Tensorflow.ipynb
@@ -262,7 +262,7 @@
    "source": [
     "def normalize_img(image):\n",
     "    \"\"\"Normalizes images: `uint8` -> `float32`.\"\"\"\n",
-    "    return tf.cast(image, tf.float32) / 255.0\n",
+    "    return tf.cast(image, tf.float32)\n",
     "\n",
     "\n",
     "train_examples = normalize_img(train_examples)\n",

--- a/integrations-and-supported-tools/tensorflow/scripts/Neptune_Tensorflow.py
+++ b/integrations-and-supported-tools/tensorflow/scripts/Neptune_Tensorflow.py
@@ -40,7 +40,7 @@ run["training/model/params"] = params
 # Normalize data for training
 def normalize_img(image):
     """Normalizes images: `uint8` -> `float32`."""
-    return tf.cast(image, tf.float32) / 255.0
+    return tf.cast(image, tf.float32)
 
 
 train_examples = normalize_img(train_examples)


### PR DESCRIPTION
# Description

Removed manual scale-down of images now that the client takes care of it

__Related to:__ Changes for image autoscaling

__Any expected test failures?__


---

Add a `[X]` to relevant checklist items

## ❔ This change

- [X] adds a new feature
- [ ] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [X] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: Windows11
- Python version: 3.10.11
- Neptune version: 1.10.0
- Affected libraries with version:
