### PR TITLE
Explicitly passing `name`

### DIFF
--- a/how-to-guides/sequential-pipelines/scripts/model_training.py
+++ b/how-to-guides/sequential-pipelines/scripts/model_training.py
@@ -10,6 +10,7 @@ from utils import get_data_features
 
 # (Neptune) Create a new run
 run = neptune.init_run(
+    name="model-training",
     monitoring_namespace="monitoring/training",
 )
 

--- a/how-to-guides/sequential-pipelines/scripts/requirements.txt
+++ b/how-to-guides/sequential-pipelines/scripts/requirements.txt
@@ -1,5 +1,4 @@
 matplotlib
-neptune
-neptune-sklearn
+neptune[sklearn]
 numpy
 scikit-learn

--- a/how-to-guides/sequential-pipelines/scripts/run_examples.sh
+++ b/how-to-guides/sequential-pipelines/scripts/run_examples.sh
@@ -4,7 +4,7 @@ export NEPTUNE_CUSTOM_RUN_ID=`date +"%Y%m%d%H%M%s%N"`
 export NEPTUNE_PROJECT="common/pipelining-support"
 
 echo "Installing requirements..."
-pip install -U -r requirements.txt
+pip install -U -q -r requirements.txt
 
 echo "Running data_preprocessing.py..."
 python data_preprocessing.py

--- a/integrations-and-supported-tools/pytorch-lightning/notebooks/Neptune_PyTorch_Lightning.ipynb
+++ b/integrations-and-supported-tools/pytorch-lightning/notebooks/Neptune_PyTorch_Lightning.ipynb
@@ -244,6 +244,7 @@
     "neptune_logger = NeptuneLogger(\n",
     "    project=\"workspace-name/project-name\",  # replace with your own (see instructions below)\n",
     "    api_token=getpass(\"Enter your Neptune API token: \"),\n",
+    "    name=\"simple-lightning-run\",\n",
     "    tags=[\"simple\", \"notebook\"],\n",
     "    log_model_checkpoints=False,  # Update to True to log model checkpoints\n",
     ")\n",
@@ -273,6 +274,7 @@
     "neptune_logger = NeptuneLogger(\n",
     "    api_key=ANONYMOUS_API_TOKEN,\n",
     "    project=\"common/pytorch-lightning-integration\",\n",
+    "    name=\"simple-lightning-run\",\n",
     "    tags=[\"simple\", \"notebook\"],\n",
     "    log_model_checkpoints=False,  # Update to True to log model checkpoints\n",
     ")"

--- a/integrations-and-supported-tools/pytorch-lightning/scripts/Neptune_Pytorch_Lightning.py
+++ b/integrations-and-supported-tools/pytorch-lightning/scripts/Neptune_Pytorch_Lightning.py
@@ -72,6 +72,7 @@ train_loader = DataLoader(train_ds, batch_size=params["batch_size"])
 neptune_logger = NeptuneLogger(
     api_key=neptune.ANONYMOUS_API_TOKEN,
     project="common/pytorch-lightning-integration",
+    name="simple-lightning-run",
     tags=["simple", "script"],
     log_model_checkpoints=True,
 )

--- a/integrations-and-supported-tools/pytorch-lightning/scripts/Neptune_Pytorch_Lightning_more_options.py
+++ b/integrations-and-supported-tools/pytorch-lightning/scripts/Neptune_Pytorch_Lightning_more_options.py
@@ -216,6 +216,7 @@ model_checkpoint = ModelCheckpoint(
 neptune_logger = NeptuneLogger(
     api_key=ANONYMOUS_API_TOKEN,
     project="common/pytorch-lightning-integration",
+    name="complex-lightning-run",
     tags=["complex", "script"],
     log_model_checkpoints=True,
 )


### PR DESCRIPTION
# Description

Explicitly passing name to `init_run()`

__Related to:__ NPT-15281, NPT-15282

__Any expected test failures?__


---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [X] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: Windows11
- Python version: 3.10.11
- Neptune version: 1.10.3
- Affected libraries with version:
