### PR TITLE
COnstraining matplotlib to <3.9

### DIFF
--- a/integrations-and-supported-tools/lightgbm/notebooks/Neptune_LightGBM.ipynb
+++ b/integrations-and-supported-tools/lightgbm/notebooks/Neptune_LightGBM.ipynb
@@ -73,7 +73,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install -U graphviz lightgbm \"neptune[lightgbm]\" \"scipy<1.12\""
+    "%pip install -q -U graphviz lightgbm \"neptune[lightgbm]\" \"scipy<1.12\" \"matplotlib<3.9\""
    ]
   },
   {
@@ -418,7 +418,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.10.11"
   },
   "vscode": {
    "interpreter": {

--- a/integrations-and-supported-tools/lightgbm/scripts/requirements.txt
+++ b/integrations-and-supported-tools/lightgbm/scripts/requirements.txt
@@ -1,4 +1,5 @@
 graphviz
 lightgbm
+matplotlib <3.9
 neptune[lightgbm]
 scipy<1.12

--- a/integrations-and-supported-tools/lightgbm/scripts/run_examples.sh
+++ b/integrations-and-supported-tools/lightgbm/scripts/run_examples.sh
@@ -1,7 +1,7 @@
 set -e
 
 echo "Installing requirements..."
-pip install -U -r requirements.txt
+pip install -q -U -r requirements.txt
 
 echo "Running Neptune_LightGBM_train.py..."
 python Neptune_LightGBM_train.py


### PR DESCRIPTION
# Description

Constraining matplotlib to <3.9 as unmaintained dependency scikitplot now uses removed attributes

__Related to:__ Fix test errors

__Any expected test failures?__


---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [ ] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: Windows11
- Python version: 3.10.11
- Neptune version: 1.10.4 
- Affected libraries with version: matplotlib 3.9.0
