### PR TITLE
fix: Updated XGBoost example to support XGBoost>=2.0

### DIFF
--- a/.github/workflows/adhoc-test.yml
+++ b/.github/workflows/adhoc-test.yml
@@ -43,7 +43,7 @@ jobs:
           - name: Upgrade pip
             run: python -m pip install --upgrade pip
           - name: Install setuptools for python>=3.12
-            if: ${{ inputs.python_version }} >= ${{ 3.12 }}
+            if: inputs.python_version >= 3.12
             run: pip install -U setuptools
           - name: Install libomp for XGBoost on MacOS
             if: inputs.os == 'macos-latest' && (contains(inputs.path, 'Neptune_XGBoost.ipynb') || contains(inputs.path, 'xgboost'))

--- a/.github/workflows/adhoc-test.yml
+++ b/.github/workflows/adhoc-test.yml
@@ -46,7 +46,7 @@ jobs:
             if: ${{ inputs.python_version }} >= ${{ 3.12 }}
             run: pip install -U setuptools
           - name: Install libomp for XGBoost on MacOS
-            if: ${{ inputs.os }} == 'macos-latest' && (contains(inputs.path, 'Neptune_XGBoost.ipynb') or contains(inputs.path, 'xgboost'))
+            if: inputs.os == 'macos-latest' && (contains(inputs.path, 'Neptune_XGBoost.ipynb') || contains(inputs.path, 'xgboost'))
             run: brew install libomp
           - name: Test scripts
             if: endsWith(inputs.path, 'scripts')

--- a/.github/workflows/adhoc-test.yml
+++ b/.github/workflows/adhoc-test.yml
@@ -45,6 +45,9 @@ jobs:
           - name: Install setuptools for python>=3.12
             if: ${{ inputs.python_version }} >= ${{ 3.12 }}
             run: pip install -U setuptools
+          - name: Install libomp for XGBoost on MacOS
+            if: ${{ inputs.os }} == 'macos-latest' && (contains(inputs.path, 'Neptune_XGBoost.ipynb') or contains(inputs.path, 'xgboost'))
+            run: brew install libomp
           - name: Test scripts
             if: endsWith(inputs.path, 'scripts')
             uses: nick-fields/retry@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -124,7 +124,7 @@ jobs:
         if: ${{ matrix.python-version }} >= ${{ 3.12 }}
         run: pip install -U setuptools
       - name: Install libomp for XGBoost on MacOS
-        if: ${{ matrix.os }} == "macos-latest" && contains(matrix.dir, "xgboost")
+        if: matrix.os == 'macos-latest' && contains(matrix.dir, 'xgboost')
         run: brew install libomp
       - name: Test examples
         uses: nick-fields/retry@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Install setuptools for python>=3.12
         if: ${{ matrix.python-version }} >= ${{ 3.12 }}
         run: pip install -U setuptools
+      - name: Install libomp for XGBoost on MacOS
+        if: ${{ matrix.os }} == "macos-latest" && contains(matrix.notebooks, "Neptune_XGBoost.ipynb")
+        run: brew install libomp
       - name: Test examples
         uses: nick-fields/retry@v3
         env:
@@ -120,6 +123,9 @@ jobs:
       - name: Install setuptools for python>=3.12
         if: ${{ matrix.python-version }} >= ${{ 3.12 }}
         run: pip install -U setuptools
+      - name: Install libomp for XGBoost on MacOS
+        if: ${{ matrix.os }} == "macos-latest" && contains(matrix.dir, "xgboost")
+        run: brew install libomp
       - name: Test examples
         uses: nick-fields/retry@v3
         env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,7 +42,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         notebooks: ${{ fromJSON(needs.get-changed-notebooks.outputs.changed_files) }}
         exclude:
-          - python-version: ${{ 3.8 }}
+          - python-version: 3.8
             notebooks: integrations-and-supported-tools/mosaicml-composer/notebooks/Neptune_MosaicML_Composer.ipynb
     steps:
       - uses: actions/checkout@main
@@ -55,7 +55,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -U -r requirements.txt
       - name: Install setuptools for python>=3.12
-        if: ${{ matrix.python-version }} >= ${{ 3.12 }}
+        if: matrix.python-version >= 3.12
         run: pip install -U setuptools
       - name: Install libomp for XGBoost on MacOS
         if: ${{ matrix.os }} == "macos-latest" && contains(matrix.notebooks, "Neptune_XGBoost.ipynb")
@@ -108,7 +108,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         dir: ${{ fromJSON(needs.get-changed-scripts.outputs.changed_dirs) }}
         exclude:
-          - python-version: ${{ 3.8 }}
+          - python-version: 3.8
             dir:
             - integrations-and-supported-tools/kedro/scripts
             - integrations-and-supported-tools/mosaicml-composer/scripts
@@ -121,7 +121,7 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Install setuptools for python>=3.12
-        if: ${{ matrix.python-version }} >= ${{ 3.12 }}
+        if: matrix.python-version >= 3.12
         run: pip install -U setuptools
       - name: Install libomp for XGBoost on MacOS
         if: matrix.os == 'macos-latest' && contains(matrix.dir, 'xgboost')

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Install setuptools for python>=3.12
         if: ${{ matrix.python-version }} >= ${{ 3.12 }}
         run: pip install -U setuptools
+      - name: Install libomp for XGBoost on MacOS
+        if: ${{ matrix.os }} == "macos-latest" && contains(matrix.notebooks, "Neptune_XGBoost.ipynb")
+        run: brew install libomp
       - name: Test examples
         uses: nick-fields/retry@v3
         env:

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -67,7 +67,7 @@ jobs:
           - use-cases/nlp/classification/keras/code/keras_nb.ipynb
         os: ["${{ inputs.os }}"]
         exclude:
-          - python-version: ${{ 3.8 }}
+          - python-version: 3.8
             notebooks: integrations-and-supported-tools/mosaicml-composer/notebooks/Neptune_MosaicML_Composer.ipynb
     steps:
       - uses: actions/checkout@main
@@ -80,7 +80,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -U -r requirements.txt
       - name: Install setuptools for python>=3.12
-        if: ${{ matrix.python-version }} >= ${{ 3.12 }}
+        if: matrix.python-version >= 3.12
         run: pip install -U setuptools
       - name: Install libomp for XGBoost on MacOS
         if: matrix.os == 'macos-latest' && contains(matrix.notebooks, 'Neptune_XGBoost.ipynb')

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -83,7 +83,7 @@ jobs:
         if: ${{ matrix.python-version }} >= ${{ 3.12 }}
         run: pip install -U setuptools
       - name: Install libomp for XGBoost on MacOS
-        if: ${{ matrix.os }} == "macos-latest" && contains(matrix.notebooks, "Neptune_XGBoost.ipynb")
+        if: matrix.os == 'macos-latest' && contains(matrix.notebooks, 'Neptune_XGBoost.ipynb')
         run: brew install libomp
       - name: Test examples
         uses: nick-fields/retry@v3

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Install setuptools for python>=3.12
         if: ${{ matrix.python-version }} >= ${{ 3.12 }}
         run: pip install -U setuptools
+      - name: Install libomp for XGBoost on MacOS
+        if: ${{ matrix.os }} == 'macos-latest' && contains(matrix.scripts, 'xgboost')
+        run: brew install libomp
       - name: Test examples
         uses: nick-fields/retry@v3
         env:

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -71,7 +71,7 @@ jobs:
           - use-cases/nlp/summarization/hf_transformers/scripts
         os: ["${{ inputs.os }}"]
         exclude:
-          - python-version: ${{ 3.8 }}
+          - python-version: 3.8
             scripts:
             - integrations-and-supported-tools/kedro/scripts
             - integrations-and-supported-tools/mosaicml-composer/scripts
@@ -84,7 +84,7 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Install setuptools for python>=3.12
-        if: ${{ matrix.python-version }} >= ${{ 3.12 }}
+        if: matrix.python-version >= 3.12
         run: pip install -U setuptools
       - name: Install libomp for XGBoost on MacOS
         if: matrix.os == 'macos-latest' && contains(matrix.scripts, 'xgboost')

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -87,7 +87,7 @@ jobs:
         if: ${{ matrix.python-version }} >= ${{ 3.12 }}
         run: pip install -U setuptools
       - name: Install libomp for XGBoost on MacOS
-        if: ${{ matrix.os }} == 'macos-latest' && contains(matrix.scripts, 'xgboost')
+        if: matrix.os == 'macos-latest' && contains(matrix.scripts, 'xgboost')
         run: brew install libomp
       - name: Test examples
         uses: nick-fields/retry@v3

--- a/integrations-and-supported-tools/xgboost/scripts/Neptune_XGBoost_sklearn_api.py
+++ b/integrations-and-supported-tools/xgboost/scripts/Neptune_XGBoost_sklearn_api.py
@@ -12,8 +12,7 @@ plt.switch_backend("agg")
 run = neptune.init_run(
     project="common/xgboost-integration",
     api_token=neptune.ANONYMOUS_API_TOKEN,
-    name="xgb-sklearn-api",
-    tags=["xgb-integration", "sklearn-api"],
+    tags=["xgb-integration", "sklearn-api", "script"],
 )
 
 # Create neptune callback
@@ -35,16 +34,7 @@ model_params = {
     "eval_metric": ["mae", "rmse"],
 }
 
-reg = xgb.XGBRegressor(**model_params)
+reg = xgb.XGBRegressor(**model_params, callbacks=[neptune_callback])
 
 # Fit the model and log metadata to the run in Neptune
-reg.fit(
-    X_train,
-    y_train,
-    early_stopping_rounds=30,
-    eval_set=[(X_train, y_train), (X_test, y_test)],
-    callbacks=[
-        neptune_callback,
-        xgb.callback.LearningRateScheduler(lambda epoch: 0.99**epoch),
-    ],
-)
+reg.fit(X_train, y_train)

--- a/integrations-and-supported-tools/xgboost/scripts/run_examples.sh
+++ b/integrations-and-supported-tools/xgboost/scripts/run_examples.sh
@@ -1,7 +1,7 @@
 set -e
 
 echo "Installing requirements..."
-pip install -U -r requirements.txt
+pip install -q -U -r requirements.txt
 
 echo "Running Neptune_XGBoost_train.py..."
 python Neptune_XGBoost_train.py


### PR DESCRIPTION
# Description

Fixed example to support xgboost>=2.0

__Related to:__ Fix test errors

__Any expected test failures?__


---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [X] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: Windows11
- Python version: 3.10.11
- Neptune version:  1.10.4
- Affected libraries with version: neptune-xgboost==1.1.1
