### PR TITLE
Update Organize and Share Dataset Versions Notebook

### DIFF
--- a/how-to-guides/data-versioning/notebooks/Organize_and_share_dataset_versions.ipynb
+++ b/how-to-guides/data-versioning/notebooks/Organize_and_share_dataset_versions.ipynb
@@ -41,9 +41,7 @@
     "* Share all the currently used dataset versions with your team\n",
     "* Assert that you are training on the latest dataset version available\n",
     "\n",
-    "By the end of this guide, you will log various dataset versions, organize them in the Neptune app and see how to share them with a persistent link.\n",
-    "\n",
-    "![image](https://neptune.ai/wp-content/uploads/neptune-datasets.png)"
+    "By the end of this guide, you will log various dataset versions, organize them in the Neptune app and see how to share them with a persistent link."
    ]
   },
   {
@@ -339,8 +337,6 @@
    "source": [
     "You and your team can also see and access all that in the Neptune app.\n",
     "Go to your project and then **Project Metadata > datasets**\n",
-    "\n",
-    "![image](https://neptune.ai/wp-content/uploads/Screenshot-from-2021-12-23-14-00-51.png)\n",
     "\n",
     "As all links in the Neptune app, the URL of the Project metadata for your project is persistent. \n",
     "\n",

--- a/how-to-guides/data-versioning/notebooks/Organize_and_share_dataset_versions.ipynb
+++ b/how-to-guides/data-versioning/notebooks/Organize_and_share_dataset_versions.ipynb
@@ -478,6 +478,7 @@
    "outputs": [],
    "source": [
     "from sklearn.ensemble import RandomForestClassifier\n",
+    "import numpy as np\n",
     "\n",
     "TEST_DATASET_PATH = \"../datasets/tables/test.csv\"\n",
     "\n",
@@ -497,7 +498,7 @@
     "X_test, y_test = test[FEATURE_COLUMNS], test[TARGET_COLUMN]\n",
     "\n",
     "rf = RandomForestClassifier(**params)\n",
-    "rf.fit(X_train, y_train)\n",
+    "rf.fit(X_train, np.ravel(y_train))\n",
     "\n",
     "score = rf.score(X_test, y_test)\n",
     "run[\"metrics/test_score\"] = score"


### PR DESCRIPTION
# Description

These commits remove the Neptune UI images from the notebook for better maintainability as well as add an adjustment to the size of the input vector for the fit function to remove the following warning from the notebook; "DataConversionWarning: A column-vector y was passed when a 1d array was expected. Please change the shape of y to (n_samples,), for example using ravel()."

---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [X] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [ ] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [ ] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: Windows
- Python version: 3.10
- Neptune version: 1.10.4
- Affected libraries with version: scikit-learn=1.5.1
