### PR TITLE
chore: Update notebook text to match the updated method for adding new tags to runs

### DIFF
--- a/how-to-guides/organize-ml-experimentation/notebooks/Organize_ML_runs.ipynb
+++ b/how-to-guides/organize-ml-experimentation/notebooks/Organize_ML_runs.ipynb
@@ -244,7 +244,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pass a list of strings to the ``.append_tag`` method of the run object."
+    "Pass a list of strings to the ``.add`` method of the run object."
    ]
   },
   {
@@ -379,7 +379,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.10.14"
   },
   "toc-showtags": false,
   "vscode": {


### PR DESCRIPTION
# Description

Update the notebook section which mentions an older version of the run method to add tags to a run.


---

## ❔ This change

- [ ] adds a new feature
- [ ] fixes breaking code
- [X] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [ ] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: Windows 11
- Python version: 3.10.14
- Neptune version: 1.10.4
- Affected libraries with version: 
