### PR TITLE
fix: remove error from notebook JSON rendering

### DIFF
--- a/how-to-guides/neptune-hpo/notebooks/Neptune_hpo.ipynb
+++ b/how-to-guides/neptune-hpo/notebooks/Neptune_hpo.ipynb
@@ -277,7 +277,7 @@
    "metadata": {},
    "source": [
     "**To view the newly created run and its metadata in the Neptune app, use the link that appeared in the cell output.**\n",
-    "\n",
+    "\n"
    ]
   },
   {


### PR DESCRIPTION
# Description

The notebook does not render due to an error is in the JSON of the notebook. This fix removes the comma causing the issue and the notebook now renders correctly. 

---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [ ] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: Windows 10
- Python version: 3.10
- Neptune version: 1.10.4
- Affected libraries with version:
