### PR TITLE
fix: W&B migration script

### DIFF
--- a/utils/migration_tools/from_wandb/README.md
+++ b/utils/migration_tools/from_wandb/README.md
@@ -3,6 +3,7 @@
 This script allows you to copy run metadata from Weights and Biases to Neptune `2.x`.
 
 ## Prerequisites
+
 - A Weights and Biases account, `wandb` library installed, and environment variables set.
 - A neptune.ai account, `neptune` python library installed, and environment variables set. Read the [docs](https://docs-legacy.neptune.ai/setup/installation/) to learn how to set up your installation.
 
@@ -16,30 +17,30 @@ To use the script, follow these steps:
 1. Enter the number of workers to use to copy the metadata. Leave blank to let `ThreadPoolExecutor` decide.
 1. Enter the W&B projects you want to export as comma-separated values. Leave blank to export all projects.
 1. The script will generate run logs in the working directory. You can change the directory with `logging.basicConfig()`. Live progress bars will also be rendered in the console.
-1. Neptune projects corresponding to the W&B projects will be created with [*workspace*](https://docs-legacy.neptune.ai/about/workspaces_and_projects/#privacy-and-access-control) visibility if they don't exist. You can change the visibility later [from the WebApp](https://docs-legacy.neptune.ai/management/changing_project_privacy/) once the project has been created, or by updating L339 in the script.
-1. The project description will be set as *Exported from <W&B project URL>*. You can change the description later [from the WebApp](https://docs-legacy.neptune.ai/setup/creating_project/#creating-a-project) once the project has been created, or by updating L338 in the script.
+1. Neptune projects corresponding to the W&B projects will be created with [_private_](https://docs-legacy.neptune.ai/about/workspaces_and_projects/#privacy-and-access-control) visibility if they don't exist. You can change the visibility later [from the WebApp](https://docs-legacy.neptune.ai/management/changing_project_privacy/) once the project has been created, or by updating L319 in the script.
+1. The project description will be set as _Exported from <W&B project URL>_. You can change the description later [from the WebApp](https://docs-legacy.neptune.ai/setup/creating_project/#creating-a-project) once the project has been created, or by updating L338 in the script.
 
 ## Metadata mapping from W&B to Neptune
 
-| Metadata | W&B | Neptune |
-| :-: | :-: | :-: |
-| Project name | example_project | example-project<sup>1</sup> |
-| Project URL | project.url | project.wandb_url |
-| Run name | run.name | run.sys.name |
-| Run ID | run.id | run.sys.custom_run_id<sup>2</sup> |
-| Notes | run.notes | run.sys.description |
-| Tags | run.tags | run.sys.tags |
-| Group | run.group | run.sys.group_tags |
-| Config | run.config | run.config<sup>3</sup> |
-| Run summary | run.summary | run.summary<sup>3</sup> |
-| Run metrics | run.scan_history() | run.<METRIC_NAME><sup>4</sup> |
-| System metrics | run.history(stream="system") | run.monitoring.<METRIC_NAME><sup>5</sup> |
-| System logs | output.log | run.monitoring.stdout |
-| Source code | code/* | run.source_code.files |
-| requirements.txt | requirements.txt | run.source_code.requirements |
-| Model checkpoints | \*.ckpt/\*checkpoint\* | run.checkpoints |
-| Other files | run.files() | run.files |
-| All W&B attributes | run.* | run.wandb.* |
+|      Metadata      |             W&B              |                 Neptune                  |
+| :----------------: | :--------------------------: | :--------------------------------------: |
+|    Project name    |       example_project        |       example-project<sup>1</sup>        |
+|    Project URL     |         project.url          |            project.wandb_url             |
+|      Run name      |           run.name           |               run.sys.name               |
+|       Run ID       |            run.id            |    run.sys.custom_run_id<sup>2</sup>     |
+|       Notes        |          run.notes           |           run.sys.description            |
+|        Tags        |           run.tags           |               run.sys.tags               |
+|       Group        |          run.group           |            run.sys.group_tags            |
+|       Config       |          run.config          |          run.config<sup>3</sup>          |
+|    Run summary     |         run.summary          |         run.summary<sup>3</sup>          |
+|    Run metrics     |      run.scan_history()      |      run.<METRIC_NAME><sup>4</sup>       |
+|   System metrics   | run.history(stream="system") | run.monitoring.<METRIC_NAME><sup>5</sup> |
+|    System logs     |          output.log          |          run.monitoring.stdout           |
+|    Source code     |           code/\*            |          run.source_code.files           |
+|  requirements.txt  |       requirements.txt       |       run.source_code.requirements       |
+| Model checkpoints  |    \*.ckpt/\*checkpoint\*    |             run.checkpoints              |
+|    Other files     |         run.files()          |                run.files                 |
+| All W&B attributes |            run.\*            |               run.wandb.\*               |
 
 <sup>1</sup> Underscores `_` in a W&B project name are replaced by a hyphen `-` in Neptune  
 <sup>2</sup> Passing the wandb.run.id as neptune.run.custom_run_id ensures that duplicate Neptune runs are not created for the same W&B run even if the script is run multiple times  
@@ -48,6 +49,7 @@ To use the script, follow these steps:
 <sup>5</sup> `system.` prefix is removed when logging to Neptune
 
 ## What is not exported
+
 - Models
 - W&B specific objects and data types
 - `run.summary` keys starting with `_`†
@@ -57,11 +59,12 @@ To use the script, follow these steps:
 † These have been excluded at the code level to prevent redundancy and noise, but can be included.
 
 ## Post-migration
-* W&B Workspace views can be recreated using Neptune's [overlaid charts](https://docs-legacy.neptune.ai/app/charts/) and [reports](https://docs-legacy.neptune.ai/app/reports/)
-* W&B Runs table views can be recreated using Neptune's [custom views](https://docs-legacy.neptune.ai/app/experiments/#custom-views)
+
+- W&B Workspace views can be recreated using Neptune's [overlaid charts](https://docs-legacy.neptune.ai/app/charts/) and [reports](https://docs-legacy.neptune.ai/app/reports/)
+- W&B Runs table views can be recreated using Neptune's [custom views](https://docs-legacy.neptune.ai/app/experiments/#custom-views)
   ![Example W&B Runs table view recreated in Neptune](https://neptune.ai/wp-content/uploads/2024/07/wandb_table.png)
-* W&B Run Overview can be recreated using Neptune's [custom dashboards](https://docs-legacy.neptune.ai/app/custom_dashboard/)
-    ![Example W&B Run Overview recreated in Neptune](https://neptune.ai/wp-content/uploads/2024/07/overview.png)
+- W&B Run Overview can be recreated using Neptune's [custom dashboards](https://docs-legacy.neptune.ai/app/custom_dashboard/)
+  ![Example W&B Run Overview recreated in Neptune](https://neptune.ai/wp-content/uploads/2024/07/overview.png)
 
 ## Performance benchmarks
 

--- a/utils/migration_tools/from_wandb/wandb_to_neptune.py
+++ b/utils/migration_tools/from_wandb/wandb_to_neptune.py
@@ -102,7 +102,9 @@ os.makedirs(tmpdirname, exist_ok=True)
 logger.info(f"Temporary directory created at {tmpdirname}")
 
 # %%
-wandb_projects = [project for project in client.projects()]  # sourcery skip: identity-comprehension
+wandb_projects = [
+    project for project in client.projects(entity=wandb_entity)
+]  # sourcery skip: identity-comprehension
 wandb_project_names = [project.name for project in wandb_projects]
 
 print(f"W&B projects found ({len(wandb_project_names)}): {wandb_project_names}")
@@ -316,7 +318,7 @@ def copy_project(wandb_project: client.project) -> None:
         management.create_project(
             name=f"{neptune_workspace}/{wandb_project_name}",
             description=f"Exported from {wandb_project.url}",
-            visibility="workspace",
+            visibility="priv",
         )
 
     with neptune.init_project(


### PR DESCRIPTION
# Description

* Fetching W&B projects only for the requested entity
* Defaulting newly created Neptune projects to have `priv` visibility

__Related to:__ <ClickUp/JIRA task name>

__Any expected test failures?__


---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [X] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [X] Refactored code ([sourcery](https://sourcery.ai/))
- [ ] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS:
- Python version:
- Neptune version:
- Affected libraries with version:
