### PR TITLE
fix: Handle `KeyError` in W&B migration script and add validation for missing Neptune workspace

### DIFF
--- a/utils/migration_tools/from_wandb/wandb_to_neptune.py
+++ b/utils/migration_tools/from_wandb/wandb_to_neptune.py
@@ -59,6 +59,11 @@ if default_neptune_workspace := os.getenv("NEPTUNE_PROJECT"):
 else:
     neptune_workspace = input("Enter Neptune workspace name: ").strip()
 
+# Validate that workspace name is not empty
+if not neptune_workspace:
+    print("Error: Neptune workspace name cannot be empty!")
+    sys.exit(1)
+
 num_workers = input(
     "Enter the number of workers to use (int). Leave empty to use ThreadPoolExecutor's defaults: "
 ).strip()
@@ -228,7 +233,7 @@ def copy_metrics(neptune_run: neptune.Run, wandb_run: client.run) -> None:
                     dict(history[key])[i]["_type"] == "table-file"
                 ):  # Not uploading W&B table-file to Neptune
                     continue
-            except (IndexError, TypeError):
+            except (IndexError, TypeError, KeyError):
                 if epoch:
                     neptune_run[key].append(value, step=epoch)
                 elif timestamp:


### PR DESCRIPTION
# Description

Include a summary of the changes and the related issue.

__Related to:__ <ClickUp/JIRA task name>

__Any expected test failures?__


---

Add a `[X]` to relevant checklist items

## ❔ This change

- [ ] adds a new feature
- [ ] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [ ] Refactored code ([sourcery](https://sourcery.ai/))
- [ ] Tested code locally
- [ ] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS:
- Python version:
- Neptune version:
- Affected libraries with version:

## Summary by Sourcery

Validate Neptune workspace input and extend exception handling in the W&B-to-Neptune migration script to catch KeyError and avoid crashes.

Bug Fixes:
- Add validation to prevent empty Neptune workspace name
- Handle KeyError when copying metrics from W&B to Neptune